### PR TITLE
Display sampler metadata when available

### DIFF
--- a/spark.proto
+++ b/spark.proto
@@ -13,6 +13,19 @@ message CommandSenderData {
   }
 }
 
+message PlatformData {
+  Type type = 1;
+  string name = 2;
+  string version = 3;
+  string minecraftVersion = 4; // optional
+
+  enum Type {
+    SERVER = 0;
+    CLIENT = 1;
+    PROXY = 2;
+  }
+}
+
 message HeapData {
   HeapMetadata metadata = 1;
   repeated HeapEntry entries = 2;
@@ -20,6 +33,7 @@ message HeapData {
 
 message HeapMetadata {
   CommandSenderData user = 1;
+  PlatformData platform = 2;
 }
 
 message HeapEntry {
@@ -41,6 +55,7 @@ message SamplerMetadata {
   ThreadDumper threadDumper = 4;
   DataAggregator dataAggregator = 5;
   string comment = 6;
+  PlatformData platform = 7;
 
   message ThreadDumper {
     Type type = 1;

--- a/src/proto.js
+++ b/src/proto.js
@@ -24,6 +24,35 @@ CommandSenderData.Type = {
     }
 };
 
+// PlatformData ========================================
+
+var PlatformData = exports.PlatformData = {};
+
+PlatformData.read = function (pbf, end) {
+    return pbf.readFields(PlatformData._readField, {type: 0, name: "", version: "", minecraftVersion: ""}, end);
+};
+PlatformData._readField = function (tag, obj, pbf) {
+    if (tag === 1) obj.type = pbf.readVarint();
+    else if (tag === 2) obj.name = pbf.readString();
+    else if (tag === 3) obj.version = pbf.readString();
+    else if (tag === 4) obj.minecraftVersion = pbf.readString();
+};
+
+PlatformData.Type = {
+    "SERVER": {
+        "value": 0,
+        "options": {}
+    },
+    "CLIENT": {
+        "value": 1,
+        "options": {}
+    },
+    "PROXY": {
+        "value": 2,
+        "options": {}
+    }
+};
+
 // HeapData ========================================
 
 var HeapData = exports.HeapData = {};
@@ -41,10 +70,11 @@ HeapData._readField = function (tag, obj, pbf) {
 var HeapMetadata = exports.HeapMetadata = {};
 
 HeapMetadata.read = function (pbf, end) {
-    return pbf.readFields(HeapMetadata._readField, {user: null}, end);
+    return pbf.readFields(HeapMetadata._readField, {user: null, platform: null}, end);
 };
 HeapMetadata._readField = function (tag, obj, pbf) {
     if (tag === 1) obj.user = CommandSenderData.read(pbf, pbf.readVarint() + pbf.pos);
+    else if (tag === 2) obj.platform = PlatformData.read(pbf, pbf.readVarint() + pbf.pos);
 };
 
 // HeapEntry ========================================
@@ -78,7 +108,7 @@ SamplerData._readField = function (tag, obj, pbf) {
 var SamplerMetadata = exports.SamplerMetadata = {};
 
 SamplerMetadata.read = function (pbf, end) {
-    return pbf.readFields(SamplerMetadata._readField, {user: null, startTime: 0, interval: 0, threadDumper: null, dataAggregator: null, comment: ""}, end);
+    return pbf.readFields(SamplerMetadata._readField, {user: null, startTime: 0, interval: 0, threadDumper: null, dataAggregator: null, comment: "", platform: null}, end);
 };
 SamplerMetadata._readField = function (tag, obj, pbf) {
     if (tag === 1) obj.user = CommandSenderData.read(pbf, pbf.readVarint() + pbf.pos);
@@ -87,6 +117,7 @@ SamplerMetadata._readField = function (tag, obj, pbf) {
     else if (tag === 4) obj.threadDumper = SamplerMetadata.ThreadDumper.read(pbf, pbf.readVarint() + pbf.pos);
     else if (tag === 5) obj.dataAggregator = SamplerMetadata.DataAggregator.read(pbf, pbf.readVarint() + pbf.pos);
     else if (tag === 6) obj.comment = pbf.readString();
+    else if (tag === 7) obj.platform = PlatformData.read(pbf, pbf.readVarint() + pbf.pos);
 };
 
 // SamplerMetadata.ThreadDumper ========================================

--- a/src/types/Sampler.js
+++ b/src/types/Sampler.js
@@ -4,8 +4,11 @@ import withHoverDetection from '../hoc/withHoverDetection'
 import classnames from 'classnames'
 
 export function Sampler({ data }) {
-    const { threads } = data
+    const { metadata, threads } = data
     return <div id="sampler">
+        {!!metadata &&
+            <Metadata metadata={metadata} />
+        }
         <div id="stack">
             {threads.map(thread => <BaseNode parents={[]} node={thread} key={thread.name} />)}
         </div>
@@ -96,3 +99,51 @@ const Name = ({ name }) => {
         <span className="method-part">{method}</span>
     </>
 }
+
+// todo: where should this go? should we split this up?
+// right now it's structured very similarly to how spark-web does it
+const Metadata = ({ metadata }) => {
+    console.log(metadata)
+
+    let userData
+    if (metadata.user && metadata.startTime && metadata.interval) {
+        let comment = ''
+        if (metadata.comment) {
+            comment = ' "' + metadata.comment + '" '
+        }
+
+        const { user, startTime, interval } = metadata
+        const { type, name } = user
+        const start = new Date(startTime);
+
+        let avatarUrl = 'https://minotar.net/avatar/Console/12.png'
+        if (type === 1) {
+            const uuid = user.uniqueId.replace(/\-/g, "")
+            avatarUrl = 'https://minotar.net/avatar/' + uuid + '/12.png'
+        }
+
+        userData = 
+            <span>
+                Profile {comment} created by <img src={avatarUrl} alt="" /> {name} at {start.toLocaleTimeString([], {hour12: true, hour: '2-digit', minute: '2-digit'})} on {start.toLocaleDateString()}, interval {interval / 1000}ms
+            </span>
+    }
+
+    let platformData
+    if (metadata.platform) {
+        const { platform } = metadata
+        const platformType = platformTypes[platform.type];
+
+        platformData =
+            <span id="platform-data">
+                {platform.name} version "{platform.version}" ({platformType})
+            </span>
+    }
+
+    return <div id="metadata">
+        {userData}
+        {userData && platformData && <br />}
+        {platformData}
+    </div>
+}
+
+const platformTypes = ["server", "client", "proxy"]


### PR DESCRIPTION
*Warning: potentially horrible React code ahead*

This is the spark-ignition counterpart to lucko/spark#58 and lucko/spark-web#4 (showing platform metadata) and also somewhat touches #1 (user/time/interval metadata).

Things to consider:
- I have no idea whether this is competent React or JSX code
- Should this be split into another "component" that can be reused in the heap summary (when implemented)?
- I haven't added any CSS for this yet. IMO it looks fine as-is, but spark-web has this metadata inside a box, and lucko/spark-web#4 makes the box expandable (hides platform by default)

Any criticism welcomed (first time doing React stuff)